### PR TITLE
Update `non-spack` path for openmpi

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ everything happened as you intended.
 Go to the directory where the Julia module files should be installed:
 ```shell
 cd /opt/hlrs/non-spack/rev-009_2022-09-01/modulefiles/mpt/2.26/gcc/10.2.0/julia # for MPT
-cd /opt/hlrs/non-spack/rev-009_2022-09-01/modulefiles/gcc/10.2.0/openmpi/julia # for OpenMPI
+cd /opt/hlrs/non-spack/rev-009_2022-09-01/modulefiles/openmpi/4.1.4/gcc/10.2.0/julia/1.9.3.lua # for OpenMPI
 ```
 Make sure the paths above are correct for `hlrs-software-stack/current`. To do so, print the
 module paths:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ everything happened as you intended.
 Go to the directory where the Julia module files should be installed:
 ```shell
 cd /opt/hlrs/non-spack/rev-009_2022-09-01/modulefiles/mpt/2.26/gcc/10.2.0/julia # for MPT
-cd /opt/hlrs/non-spack/rev-009_2022-09-01/modulefiles/openmpi/4.1.4/gcc/10.2.0/julia/1.9.3.lua # for OpenMPI
+cd /opt/hlrs/non-spack/rev-009_2022-09-01/modulefiles/openmpi/4.1.4/gcc/10.2.0/julia # for OpenMPI
 ```
 Make sure the paths above are correct for `hlrs-software-stack/current`. To do so, print the
 module paths:

--- a/modulefiles/hawk/mpt/UNKNOWN-VERSION-cuda.lua
+++ b/modulefiles/hawk/mpt/UNKNOWN-VERSION-cuda.lua
@@ -39,12 +39,12 @@ setenv("JULIA_HOME", base)
 setenv("JULIA_VERSION", juliaVersion)
 
 -- Julia-related settings
-setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
+-- setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
 -- Prevent installation of BinaryBuilder.jl CUDA
-setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
+-- setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
 
 -- MPI-related settings
-setenv("JULIA_MPI_BINARY", "system")
+-- setenv("JULIA_MPI_BINARY", "system")
 setenv("MPI_SHEPHERD", "true")
 
 -- CUDA-related settings

--- a/modulefiles/hawk/mpt/UNKNOWN-VERSION.lua
+++ b/modulefiles/hawk/mpt/UNKNOWN-VERSION.lua
@@ -38,10 +38,10 @@ setenv("JULIA_HOME", base)
 setenv("JULIA_VERSION", juliaVersion)
 
 -- Julia-related settings
-setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
+-- setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
 -- Prevent installation of BinaryBuilder.jl CUDA
-setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
+-- setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
 
 -- MPI-related settings
-setenv("JULIA_MPI_BINARY", "system")
+-- setenv("JULIA_MPI_BINARY", "system")
 setenv("MPI_SHEPHERD", "true")

--- a/modulefiles/hawk/openmpi/UNKNOWN-VERSION-cuda.lua
+++ b/modulefiles/hawk/openmpi/UNKNOWN-VERSION-cuda.lua
@@ -39,12 +39,12 @@ setenv("JULIA_HOME", base)
 setenv("JULIA_VERSION", juliaVersion)
 
 -- Julia-related settings
-setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
+-- setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
 -- Prevent installation of BinaryBuilder.jl CUDA
-setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
+-- setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
 
 -- MPI-related settings
-setenv("JULIA_MPI_BINARY", "system")
+-- setenv("JULIA_MPI_BINARY", "system")
 setenv("UCX_WARN_UNUSED_ENV_VARS", "n") -- suppress UCX warnings
 
 -- CUDA-related settings

--- a/modulefiles/hawk/openmpi/UNKNOWN-VERSION.lua
+++ b/modulefiles/hawk/openmpi/UNKNOWN-VERSION.lua
@@ -38,10 +38,10 @@ setenv("JULIA_HOME", base)
 setenv("JULIA_VERSION", juliaVersion)
 
 -- Julia-related settings
-setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
+-- setenv("JULIA_DEPOT_PATH", pathJoin(os.getenv("HOME"), ".julia", os.getenv("SITE_NAME"), os.getenv("SITE_PLATFORM_NAME"))) -- $HOME/.julia/HLRS/<machine>
 -- Prevent installation of BinaryBuilder.jl CUDA
-setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
+-- setenv("JULIA_CUDA_USE_BINARYBUILDER", "false")
 
 -- MPI-related settings
-setenv("JULIA_MPI_BINARY", "system")
+-- setenv("JULIA_MPI_BINARY", "system")
 setenv("UCX_WARN_UNUSED_ENV_VARS", "n") -- suppress UCX warnings


### PR DESCRIPTION
The current version from #1 should work.
If not, this is the cleaner version.

Plus, I out commented the setters for the environment variables since they are either deprecated or they overwrite user-defined environment variables.